### PR TITLE
Adds the git ca to the git aliases

### DIFF
--- a/dotfiles/gitconfig
+++ b/dotfiles/gitconfig
@@ -16,6 +16,7 @@
 [alias]
   s = status
   ci = commit -m
+  ca = commit -am
   p = push
   pu = pull
   undo-commit = reset --soft HEAD^


### PR DESCRIPTION
The git ca calls the commando "git commit -am" that stages all created and modified files and then commit them with a message.
